### PR TITLE
release v1.1.0 (#6)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # default is / which breaks drone
+    pull-request-branch-name:
+      separator: "-"
+    # not created automatically for version updates so only security ones are created
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0 
+    

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 
 RUN apt update && apt install -y curl

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 onetask.ai GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build
+++ b/build
@@ -1,3 +1,12 @@
 #!/bin/bash
+IS_ARM64=""
+currentArch="$(uname -m)"
+if [ "$currentArch" == "arm64" ];
+then
+    echo "architecture: arm64"
+    IS_ARM64="_arm64"
+else
+    echo "architecture: $currentArch"
+fi
 
-docker build -t registry.dev.onetask.ai/code-kern-ai/refinery-record-ide-env:dev .
+docker build -t registry.dev.onetask.ai/code-kern-ai/refinery-record-ide-env:dev$IS_ARM64 .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-numpy==1.21.0
+numpy==1.23.2
 textblob==0.17.1
-scikit-learn==1.0.1
-Vocabulary==1.0.4
-nltk==3.6.7
-spacy==3.2.2
-requests==2.13.0
+scikit-learn==1.1.2
+nltk==3.7
+spacy==3.4.1
+requests==2.28.1


### PR DESCRIPTION
* Update LICENSE

* Create dependabot.yml

* Bump numpy from 1.21.0 to 1.22.0

Bumps [numpy](https://github.com/numpy/numpy) from 1.21.0 to 1.22.0.
- [Release notes](https://github.com/numpy/numpy/releases)
- [Changelog](https://github.com/numpy/numpy/blob/main/doc/RELEASE_WALKTHROUGH.rst)
- [Commits](https://github.com/numpy/numpy/compare/v1.21.0...v1.22.0)

---
updated-dependencies:
- dependency-name: numpy dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>

* bump python version

* Bump requests from 2.13.0 to 2.20.0

Bumps [requests](https://github.com/psf/requests) from 2.13.0 to 2.20.0.
- [Release notes](https://github.com/psf/requests/releases)
- [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md)
- [Commits](https://github.com/psf/requests/compare/v2.13.0...v2.20.0)

---
updated-dependencies:
- dependency-name: requests dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>

* remove depricated library vocabulary

* updates requirements, adds arm64 tag to build script (#5)

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Felix Kirsch <40427105+FelixKirsch@users.noreply.github.com>